### PR TITLE
Add option to enable chat widget in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ plugins: [
     resolve: 'gatsby-plugin-drift',
     options: {
       appId: 'YOUR-APP-ID',
+      enableDuringDevelop: true // Optional. Enables Drift chat widget when running Gatsby dev server. Defaults to false.
     },
   },
 ],

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,13 @@
-exports.onInitialClientRender = () => {
-  if (process.env.NODE_ENV === 'production' && typeof drift === 'object' && window.driftAppId) {
+exports.onInitialClientRender = (
+  _,
+  pluginOptions = { enableDuringDevelop: false }
+) => {
+  if (
+    (pluginOptions.enableDuringDevelop ||
+      process.env.NODE_ENV === 'production') &&
+    typeof drift === 'object' &&
+    window.driftAppId
+  ) {
     window.drift.SNIPPET_VERSION = '0.3.1';
     window.drift.load(window.driftAppId);
   }

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,13 @@
 import React from 'react';
 
-exports.onRenderBody = ({setPostBodyComponents}, pluginOptions) => {
-  if (process.env.NODE_ENV === 'production') {
+exports.onRenderBody = (
+  { setPostBodyComponents },
+  pluginOptions = { enableDuringDevelop: false }
+) => {
+  if (
+    pluginOptions.enableDuringDevelop ||
+    process.env.NODE_ENV === 'production'
+  ) {
     return setPostBodyComponents([
       <script
         key={'gatsby-plugin-drift'}


### PR DESCRIPTION
Adds an optional `enableDuringDevelop` property to the plugin config in `gatsby-config.js`. If set to `true`, the chat widget will load on Gatsby's dev server after running `gatsby-develop`. If `false` the chat widget will only load in production mode.

If `enableDuringDevelop` is not set in the config, the default value is set to `false` to preserve the original behavior of the plugin, where chat widget only loads in production.

Changes to line lengths in formatting were done by Prettier, could be changed to match original formatting if those changes aren't wanted.